### PR TITLE
GH-70 Improve performance of fetching members.

### DIFF
--- a/components/team/Team.vue
+++ b/components/team/Team.vue
@@ -16,6 +16,9 @@
 </template>
 
 <script setup lang="ts">
-import TeamMember from "~/components/team/TeamMember.vue";
-const fetchResult = await $fetch("/api/members");
+const fetchResult = ref([]);
+
+onMounted(async () => {
+  fetchResult.value = await $fetch("/api/members");
+});
 </script>

--- a/components/team/Team.vue
+++ b/components/team/Team.vue
@@ -16,16 +16,16 @@
 </template>
 
 <script setup lang="ts">
-interface MemberData {
+interface TeamMember {
   id: string;
   attributes: any;
 }
 
-interface Member {
-  data: MemberData[];
+interface Team {
+  data: TeamMember[];
 }
 
-const fetchResult: Ref<Member> = ref({ data: [] });
+const fetchResult: Ref<Team> = ref({ data: [] });
 
 onMounted(async () => {
   fetchResult.value = await $fetch("/api/members");

--- a/components/team/Team.vue
+++ b/components/team/Team.vue
@@ -16,7 +16,16 @@
 </template>
 
 <script setup lang="ts">
-const fetchResult = ref([]);
+interface MemberData {
+  id: string;
+  attributes: any;
+}
+
+interface Member {
+  data: MemberData[];
+}
+
+const fetchResult: Ref<Member> = ref({ data: [] });
 
 onMounted(async () => {
   fetchResult.value = await $fetch("/api/members");

--- a/components/team/TeamMember.vue
+++ b/components/team/TeamMember.vue
@@ -38,11 +38,33 @@
   </div>
 </template>
 
+
 <script lang="ts">
-export default {
+interface Role {
+  attributes: {
+    name: string;
+  };
+}
+
+interface Member {
+  avatar_url: string;
+  name: string;
+  team_roles: {
+    data: Role[];
+  };
+  github?: string;
+  linkedin?: string;
+}
+
+interface Props {
+  member: Member;
+  index: Number;
+}
+
+export default defineComponent({
   props: {
     member: {
-      type: Object,
+      type: Object as PropType<Member>,
       required: true,
     },
     index: {
@@ -50,10 +72,12 @@ export default {
       required: true,
     },
   },
-  computed: {
-    memberRoles() {
-      return this.member.team_roles.data;
-    },
+  setup(props: Props) {
+    const memberRoles = computed(() => props.member.team_roles.data);
+
+    return {
+      memberRoles
+    };
   },
-};
+});
 </script>

--- a/components/team/TeamMember.vue
+++ b/components/team/TeamMember.vue
@@ -50,5 +50,10 @@ export default {
       required: true,
     },
   },
+  computed: {
+    memberRoles() {
+      return this.member.team_roles.data;
+    },
+  },
 };
 </script>


### PR DESCRIPTION
Average time of page loading before changes:

![image](https://github.com/EternalCodeTeam/website/assets/65517973/d87e04e9-0166-4bef-b618-c5d963f2bfc9)


Average time of page loading after changes:
![image](https://github.com/EternalCodeTeam/website/assets/65517973/ab137d2e-d5d8-444c-acda-3c6d902db0b0)


In the TeamMember component script, I added computed properties called `memberRoles` to avoid recalculating `member.team_roles.data` multiple times during rendering.

In the Team component script, I utilized a `ref` to store the result of the fetch operation and used `onMounted` to trigger the fetch only after the component is mounted. This prevents unnecessary fetch calls during each rendering.
